### PR TITLE
fix: call cleanup_html if there's a childNodes

### DIFF
--- a/front-end/load-script.php
+++ b/front-end/load-script.php
@@ -173,7 +173,9 @@ class Load_Scripts {
                 //  The empty string is messed up the `childNodes` so can't count it properly. Unfortunately,
                 //  the `shortcode` identified the same as an empty string type, `#text`.
                 $body = $dom->getElementsByTagName('body')->item(0)->childNodes;
-                $body = $this->cleanup_html($body);
+                if($body) {
+                    $body = $this->cleanup_html($body);
+                }
             }
 
             if ( sizeof($player_pos) !== 0 && $player_pos[0] !== '-1' ) {


### PR DESCRIPTION
Inside `hook_player_into_content` , if there's a content we do a cleaning HTML by calling `$this->cleanup_html`, if we refer into it, we can see that `cleanup_html` only accept array as their parameters. The problem that we are facing now is sometimes the child node is `NULL` and this type of data causes crashes in WordPress. To fix that issue, we need to add conditional logic before cleaning the HTML.