### PR TITLE
feat: convert old player to new geo player

### DIFF
--- a/dashboard/admin.php
+++ b/dashboard/admin.php
@@ -160,6 +160,20 @@ class DM_Admin {
     }
 
     public function load_migration_page() {
+        $tab = isset($_GET['tab']) ? self::sanitize_this('tab', 'GET') : ''; //
+        $prefix = '';
+        $action = self::sanitize_this('action', 'GET'); // phpcs:ignore WordPress.Security.NonceVerification
+        
+        switch($action):
+            case "save_data":
+                $save_data = self::sanitize_this('dm_save_data');
+                if ( wp_verify_nonce($save_data, 'dm_save_data') )
+                self::store_general_settings($_POST, $prefix . $tab);
+                
+                break;
+            endswitch;
+            
+        $options = get_option('dm_ce_options_' . $prefix . $tab);
         require DM__PATH . 'dashboard/views/migration/page.php';
     }
 
@@ -175,6 +189,10 @@ class DM_Admin {
             // Content options
             if (!empty($params['sort_by']) && $params['sort_by'] !== null)
                 $dm_ce_data += ['sort_by' => self::sanitize_this('sort_by')];
+
+
+            if (!empty($params['convert_old_player']) && $params['convert_old_player'] !== null)
+                $dm_ce_data += ['convert_old_player' => self::sanitize_this('convert_old_player')];            
 
             if (!empty($params['channel_name']) && $params['channel_name'] !== null)
                 $dm_ce_data += ['owners' => self::sanitize_this('channel_name')];

--- a/dashboard/views/migration/convert-player.php
+++ b/dashboard/views/migration/convert-player.php
@@ -8,9 +8,10 @@
         <tbody>
             <tr>
                 <th scope="row"><?php echo __('Convert Old Iframes'); ?> <span class="detail-info">?<span
-                            class="tooltip">By activating this option, all Dailymotion iframe players inside your
-                            content will
-                            be converted to new Dailymotion Player</span></span></th>
+                            class="tooltip">Old iframes will be replaced by their new version. Learn more about
+                            integration methods in <a title="Developer docs"
+                                href="https://developers.dailymotion.com/player/#Integration-methods">our developer
+                                doc.</a></span></span></th>
                 <td>
                     <fieldset>
                         <legend class="screen-reader-text"><span><?php echo __('Conver Old Player'); ?></span></legend>
@@ -19,7 +20,8 @@
                                 <?php echo (isset($options['convert_old_player'])) ? 'checked' : '' ?>>
                         </label>
                     </fieldset>
-                    <p class="description">Toggle on/off to enable/disable auto convert old player</p>
+                    <p class="description">Toggle on/off to automatically update all old dailymotion video iframes into
+                        their latest version.</p>
                 </td>
             </tr>
 

--- a/dashboard/views/migration/convert-player.php
+++ b/dashboard/views/migration/convert-player.php
@@ -1,0 +1,33 @@
+<form action="<?php echo get_admin_url() . 'admin.php?page=dm-migration&tab=convert-player&action=save_data'; ?>"
+    method="post">
+
+    <?php wp_nonce_field("dm_save_data", "dm_save_data", true);?>
+
+    <table class="form-table" role="presentation">
+
+        <tbody>
+            <tr>
+                <th scope="row"><?php echo __('Convert Old Iframes'); ?> <span class="detail-info">?<span
+                            class="tooltip">By activating this option, all Dailymotion iframe players inside your
+                            content will
+                            be converted to new Dailymotion Player</span></span></th>
+                <td>
+                    <fieldset>
+                        <legend class="screen-reader-text"><span><?php echo __('Conver Old Player'); ?></span></legend>
+                        <label for="convert_old_player">
+                            <input name="convert_old_player" type="checkbox" id="convert_old_player" value="1"
+                                <?php echo (isset($options['convert_old_player'])) ? 'checked' : '' ?>>
+                        </label>
+                    </fieldset>
+                    <p class="description">Toggle on/off to enable/disable auto convert old player</p>
+                </td>
+            </tr>
+
+        </tbody>
+
+    </table>
+
+    <p class="submit">
+        <input type="submit" name="submit" id="submit" class="button button-primary" value="Save">
+    </p>
+</form>

--- a/dashboard/views/migration/header.php
+++ b/dashboard/views/migration/header.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Header admin dashboard
+ *
+ * Please refer `$action` to admin.php on `load_automated_embed_page()` function
+ */
+?>
+<h1 class="wp-heading-inline">
+    <?php echo __('Migrations Settings'); ?>
+</h1>
+
+<hr class="wp-header-end">
+
+<nav class="nav-tab-wrapper wp-clearfix">
+    <a href="<?php echo get_bloginfo('wpurl'); ?>/wp-admin/admin.php?page=dm-migration"
+        class="nav-tab<?php echo $tab === '' ? ' nav-tab-active' : ''; ?>"
+        <?php echo $tab === '' ? ' aria-current="page' : ''; ?>">Database Migrations</a>
+    <a href="<?php echo get_bloginfo('wpurl'); ?>/wp-admin/admin.php?page=dm-migration&tab=convert-player"
+        class="nav-tab<?php echo $tab === 'convert-player' ? ' nav-tab-active' : ''; ?>"
+        <?php echo $tab === 'convert-player' ? ' aria-current="page' : ''; ?>">Convert Old Iframes</a>
+</nav>

--- a/dashboard/views/migration/migration.php
+++ b/dashboard/views/migration/migration.php
@@ -1,0 +1,39 @@
+<p class="dm-migration-instruction">The migration is only for update from <strong>v1.0.4</strong> to
+    <strong>v1.1.0</strong>. If it's the first time you use this plugin, you don't need to do this action.
+</p>
+
+<p><button type="button" id="migrate-database" class="button button-primary">Migrate database</button></p>
+
+<script type="text/javascript">
+const button = document.getElementById('migrate-database')
+const apiUrl = "<?php echo rest_url(); ?>"
+const wpNonce = "<?php echo wp_create_nonce('wp_rest'); ?>"
+
+const headerEnd = document.querySelector('.dm-migration-instruction')
+
+button.addEventListener('click', () => {
+    button.disabled = true
+
+    fetch(apiUrl + 'dm/v1/migration', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': wpNonce
+            }
+        })
+        .then(res => res.json())
+        .then(data => {
+
+            setTimeout(() => {
+                button.disabled = false
+                headerEnd.insertAdjacentHTML('beforebegin',
+                    '<div id="setting-error-settings_updated" class="notice notice-success settings-error is-dismissible"><p><strong>Migration succeed</strong></p> </div>'
+                )
+            }, 1000)
+        })
+        .catch(err => {
+            // console.log(err)
+        })
+})
+</script>

--- a/dashboard/views/migration/page.php
+++ b/dashboard/views/migration/page.php
@@ -9,45 +9,19 @@
 
 <div class="wrap">
 
-    <h1 class="wp-heading-inline">
-        <?php echo __('Database Migration'); ?>
-    </h1>
+    <?php require DM__PATH . 'dashboard/views/migration/header.php';?>
 
-    <hr class="wp-header-end">
 
-    <p class="dm-migration-instruction">The migration is only for update from <strong>v1.0.4</strong> to <strong>v1.1.0</strong>. If it's the first time you use this plugin, you don't need to do this action.</p>
+    <?php
 
-    <p><button type="button" id="migrate-database" class="button button-primary">Migrate database</button></p>
+    if ($tab === 'convert-player') {
+        require DM__PATH . 'dashboard/views/migration/convert-player.php';
+    } else  {
+        require DM__PATH . 'dashboard/views/migration/migration.php';
+    }
 
-    <script type="text/javascript">
-        const button = document.getElementById('migrate-database')
-        const apiUrl = "<?php echo rest_url(); ?>"
-        const wpNonce = "<?php echo wp_create_nonce('wp_rest'); ?>"
+    ?>
 
-        const headerEnd = document.querySelector('.dm-migration-instruction')
 
-        button.addEventListener('click', () => {
-            button.disabled = true
 
-            fetch( apiUrl + 'dm/v1/migration', {
-                method: 'POST',
-                credentials: 'same-origin',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-WP-Nonce': wpNonce
-                }
-            })
-                .then( res => res.json())
-                .then( data => {
-
-                    setTimeout(() => {
-                        button.disabled = false
-                        headerEnd.insertAdjacentHTML('beforebegin', '<div id="setting-error-settings_updated" class="notice notice-success settings-error is-dismissible"><p><strong>Migration succeed</strong></p> </div>')
-                    }, 1000)
-                })
-                .catch( err => {
-                    // console.log(err)
-                })
-        })
-    </script>
 </div>

--- a/front-end/load-script.php
+++ b/front-end/load-script.php
@@ -260,7 +260,8 @@ class Load_Scripts {
                 * replace all dailymotion iframe
                 */
                 if($videoUrl && str_contains($videoUrl, 'dailymotion.com')) {
-                    $videoId = end(explode('/', parse_url($videoUrl, PHP_URL_PATH)));
+                    $splitVideoPath = explode('/', parse_url($videoUrl, PHP_URL_PATH));
+                    $videoId = end($splitVideoPath);
                     $content = str_replace($iframe, '[dm-player videoid="'.$videoId.'"]', $content);
                 }
             }

--- a/front-end/load-script.php
+++ b/front-end/load-script.php
@@ -15,6 +15,7 @@ class Load_Scripts {
     public function __construct() {
         add_action('wp_footer', array($this, 'load_script'));
         add_filter('the_content', array($this, 'hook_player_into_content'));
+        add_filter('the_content', array($this, 'migrate_old_player_to_custom_embed'));
     }
 
     /**
@@ -228,6 +229,42 @@ class Load_Scripts {
             return $new_content;
 
 
+        } // if the post and the page
+
+        return $content;
+    }
+
+    public function migrate_old_player_to_custom_embed($content) {
+        $regexGetIframe = '(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))';
+        $regexIframeSrc = '<iframe[^>]+src=(?:\"|\')\K(.[^">]+?)(?=\"|\')';
+        
+        if (is_single() || is_page() && !is_home() && !is_front_page()) {
+            /**
+             * get settings from DB
+             */
+            $options_general = get_option('dm_ce_options_convert-player');
+            if(!isset( $options_general['convert_old_player'] )) {
+                return $content;
+            }
+
+            /**
+             * get all iframes
+             */
+            preg_match_all("/$regexGetIframe/", $content, $allIframes);
+
+            foreach ($allIframes[0] as $iframe) {
+                preg_match("/$regexIframeSrc/", $iframe, $result);
+                $videoUrl = $result[0];
+                
+                /**
+                * replace all dailymotion iframe
+                */
+                if($videoUrl && str_contains($videoUrl, 'dailymotion.com')) {
+                    $videoId = end(explode('/', parse_url($videoUrl, PHP_URL_PATH)));
+                    $content = str_replace($iframe, '[dm-player videoid="'.$videoId.'"]', $content);
+                }
+            }
+            return $content;
         } // if the post and the page
 
         return $content;

--- a/wp-plugin-custom-embed.php
+++ b/wp-plugin-custom-embed.php
@@ -5,18 +5,18 @@
  * Description: Embed video from Dailymotion
  * Author: DMVS APAC Team
  * Author URI: https://github.com/DMVS-APAC
- * Version: 1.4.0
+ * Version: 1.5.0-1
  * Plugin URI: https://github.com/DMVS-APAC/wp-plugin-custom-embed
  * Download
  *
- * @version 1.4.0
+ * @version 1.5.0-1
  */
 
 if (! defined('ABSPATH') ) {
     exit; // Exit if accessed directly.
 }
 
-define('DM_CE__VERSION', '1.4.0');
+define('DM_CE__VERSION', '1.5.0-1');
 define('DM__FILE__', __FILE__);
 define('DM__PLUGIN_BASE', plugin_basename(DM__FILE__));
 define('DM__PATH', plugin_dir_path(DM__FILE__));


### PR DESCRIPTION
There's a request from our client, they want to migrate the existing Dailymotion player into the new one or GEO Dailymotion Player. in this update, the user will be able to configure the old player replacement, if the user chooses to toggle ON this feature, all Old Dailymotion embed players will be migrated to Custom Embed Player. For a detailed explanation, you can read it on [here](https://www.notion.so/dmvsapac/WPP-Discovery-Migrating-old-WordPress-iframes-to-new-player-embed-2b20f6e043ff4531933b0b0aca3aeedb)

Sorry if there's a lot of changes that not related to the logic, I'm using prettier in my editor